### PR TITLE
re-apply HPC-UGent customisations for Singularity v2.5.0

### DIFF
--- a/bdist_rpm.sh
+++ b/bdist_rpm.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+
+# Clean
+rm -Rf BUILD SOURCES SPECS RPMS BUILDROOT
+mkdir -p BUILD SOURCES SPECS RPMS BUILDROOT
+
+./autogen.sh
+./configure --prefix=/usr --sysconfdir=/etc
+make dist
+
+
+VERSION=$(grep "Version:.*[0-9]" singularity.spec | tr -s " " |  awk '{print $2;}')
+GITTAG=$(git log --format=%ct.%h -1)
+
+# Copy required files
+cp "singularity-${VERSION}.tar.gz" "SOURCES"
+cp singularity.spec "SPECS"
+
+
+rpmbuild --define "gittag ${GITTAG}" --define "_topdir $PWD" -ba SPECS/singularity.spec
+
+# Clean
+rm -Rf "singularity-${VERSION}.tar.gz"

--- a/etc/init
+++ b/etc/init
@@ -37,3 +37,25 @@ export SINGULARITYENV_PATH
 # Don't save the shell's HISTFILE
 SINGULARITYENV_HISTFILE=""
 export SINGULARITYENV_HISTFILE
+
+# HPC-UGent only allows users in the 'gsingularity' group to use Singularity
+SINGULARITY_VSC_GROUP="gsingularity"
+
+# $IMAGE_PATH will be empty if realpath is not able to find
+# $SINGULARITY_IMAGE in the file system.
+IMAGE_PATH="$(/usr/bin/realpath "$SINGULARITY_IMAGE" 2> /dev/null)"
+if [ -z "$IMAGE_PATH" ]; then
+    echo "ERROR: $SINGULARITY_IMAGE is not a valid image" >&2
+    exit 1
+fi
+
+# Detect user groups and allow $SINGULARITY_VSC_GROUP
+if /usr/bin/id -nG | /usr/bin/grep -qw "$SINGULARITY_VSC_GROUP"; then
+    echo "$USER belongs to $SINGULARITY_VSC_GROUP"
+else
+    echo "ERROR: $USER does not belong to $SINGULARITY_VSC_GROUP" >&2
+    exit 2
+fi
+
+# Log user Singularity command for ELK
+/usr/bin/logger -t singularity "user=$USER image=$IMAGE_PATH jobid=${PBS_JOBID:-} cmd=$SINGULARITY_COMMAND"

--- a/singularity.spec.in
+++ b/singularity.spec.in
@@ -84,17 +84,11 @@ fi
 
 %post
 /usr/bin/chown root:%{gsingularityid} %{_libexecdir}/singularity/bin/action-suid
-/usr/bin/chown root:%{gsingularityid} %{_libexecdir}/singularity/bin/create-suid
-/usr/bin/chown root:%{gsingularityid} %{_libexecdir}/singularity/bin/expand-suid
-/usr/bin/chown root:%{gsingularityid} %{_libexecdir}/singularity/bin/export-suid
-/usr/bin/chown root:%{gsingularityid} %{_libexecdir}/singularity/bin/import-suid
 /usr/bin/chown root:%{gsingularityid} %{_libexecdir}/singularity/bin/mount-suid
+/usr/bin/chown root:%{gsingularityid} %{_libexecdir}/singularity/bin/start-suid
 /usr/bin/chmod u+s %{_libexecdir}/singularity/bin/action-suid
-/usr/bin/chmod u+s %{_libexecdir}/singularity/bin/create-suid
-/usr/bin/chmod u+s %{_libexecdir}/singularity/bin/expand-suid
-/usr/bin/chmod u+s %{_libexecdir}/singularity/bin/export-suid
-/usr/bin/chmod u+s %{_libexecdir}/singularity/bin/import-suid
 /usr/bin/chmod u+s %{_libexecdir}/singularity/bin/mount-suid
+/usr/bin/chmod u+s %{_libexecdir}/singularity/bin/start-suid
 
 %install
 %{__make} install DESTDIR=$RPM_BUILD_ROOT %{?mflags_install}

--- a/singularity.spec.in
+++ b/singularity.spec.in
@@ -27,7 +27,7 @@
 Summary: Application and environment virtualization
 Name: singularity
 Version: @PACKAGE_VERSION@
-Release: %{_rel}%{?dist}
+Release: %{_rel}%{gittag}%{?dist}.ug
 # https://spdx.org/licenses/BSD-3-Clause-LBNL.html
 License: BSD-3-Clause-LBNL
 Group: System Environment/Base
@@ -42,6 +42,12 @@ Requires: squashfs
 %else
 Requires: squashfs-tools
 %endif
+
+# Required by init script to detect real paths
+Requires: coreutils
+
+# Set vsc gsingularity group id
+%define gsingularityid 2640213
 
 Requires: %{name}-runtime = %{version}-%{release}
 
@@ -76,6 +82,19 @@ fi
 %configure
 %{__make} %{?mflags}
 
+%post
+/usr/bin/chown root:%{gsingularityid} %{_libexecdir}/singularity/bin/action-suid
+/usr/bin/chown root:%{gsingularityid} %{_libexecdir}/singularity/bin/create-suid
+/usr/bin/chown root:%{gsingularityid} %{_libexecdir}/singularity/bin/expand-suid
+/usr/bin/chown root:%{gsingularityid} %{_libexecdir}/singularity/bin/export-suid
+/usr/bin/chown root:%{gsingularityid} %{_libexecdir}/singularity/bin/import-suid
+/usr/bin/chown root:%{gsingularityid} %{_libexecdir}/singularity/bin/mount-suid
+/usr/bin/chmod u+s %{_libexecdir}/singularity/bin/action-suid
+/usr/bin/chmod u+s %{_libexecdir}/singularity/bin/create-suid
+/usr/bin/chmod u+s %{_libexecdir}/singularity/bin/expand-suid
+/usr/bin/chmod u+s %{_libexecdir}/singularity/bin/export-suid
+/usr/bin/chmod u+s %{_libexecdir}/singularity/bin/import-suid
+/usr/bin/chmod u+s %{_libexecdir}/singularity/bin/mount-suid
 
 %install
 %{__make} install DESTDIR=$RPM_BUILD_ROOT %{?mflags_install}
@@ -106,19 +125,19 @@ rm -rf $RPM_BUILD_ROOT
 %{_libexecdir}/singularity/python
 
 # Binaries
-%{_libexecdir}/singularity/bin/builddef
-%{_libexecdir}/singularity/bin/cleanupd
-%{_libexecdir}/singularity/bin/get-section
-%{_libexecdir}/singularity/bin/mount
-%{_libexecdir}/singularity/bin/image-type
-%{_libexecdir}/singularity/bin/prepheader
-%{_libexecdir}/singularity/bin/docker-extract
+%attr(0750, root, root) %{_libexecdir}/singularity/bin/builddef
+%attr(0750, root, root) %{_libexecdir}/singularity/bin/cleanupd
+%attr(0750, root, root) %{_libexecdir}/singularity/bin/get-section
+%attr(0750, root, root) %{_libexecdir}/singularity/bin/mount
+%attr(0750, root, root) %{_libexecdir}/singularity/bin/image-type
+%attr(0750, root, root) %{_libexecdir}/singularity/bin/prepheader
+%attr(0750, root, root) %{_libexecdir}/singularity/bin/docker-extract
 
 # Directories
 %{_libexecdir}/singularity/bootstrap-scripts
 
 #SUID programs
-%attr(4755, root, root) %{_libexecdir}/singularity/bin/mount-suid
+%attr(4750, root, root) %{_libexecdir}/singularity/bin/mount-suid
 
 %files runtime
 %dir %{_libexecdir}/singularity
@@ -138,9 +157,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_libexecdir}/singularity/cli/run.*
 %{_libexecdir}/singularity/cli/shell.*
 %{_libexecdir}/singularity/cli/test.*
-%{_libexecdir}/singularity/bin/action
-%{_libexecdir}/singularity/bin/start
-%{_libexecdir}/singularity/bin/docker-extract
+%attr(0750, root, root) %{_libexecdir}/singularity/bin/action
+%attr(0750, root, root) %{_libexecdir}/singularity/bin/start
+%attr(0750, root, root) %{_libexecdir}/singularity/bin/docker-extract
 %{_libexecdir}/singularity/functions
 %{_libexecdir}/singularity/handlers
 %{_libexecdir}/singularity/image-handler.sh
@@ -151,8 +170,8 @@ rm -rf $RPM_BUILD_ROOT
 %{_sysconfdir}/bash_completion.d/singularity
 
 #SUID programs
-%attr(4755, root, root) %{_libexecdir}/singularity/bin/action-suid
-%attr(4755, root, root) %{_libexecdir}/singularity/bin/start-suid
+%attr(4750, root, root) %{_libexecdir}/singularity/bin/action-suid
+%attr(4750, root, root) %{_libexecdir}/singularity/bin/start-suid
 
 %files devel
 %defattr(-, root, root)


### PR DESCRIPTION
`2.5.0-ugent` branch now corresponds with Singularity v2.5.0 release

These changes are the ported customizations we have added for our current Singularity installation, i.e.:

* limit use of `singularity` to members of `gsingularity` group
* limit location of Singularity container images to scratch & local directories

I ran the resulting Singularity installation for a quick test drive on a `skitty` workernode, seems to work as expected.

There's a known issue with Singularity 2.5.0 when used in directories on an NFS-mounted filesystem (cfr. ), but I don't think that's a blocker for us (easy to work around).